### PR TITLE
Fix move base state

### DIFF
--- a/flexbe_navigation_states/src/flexbe_navigation_states/move_base_state.py
+++ b/flexbe_navigation_states/src/flexbe_navigation_states/move_base_state.py
@@ -88,3 +88,9 @@ class MoveBaseState(EventState):
         if not self._client.has_result(self._action_topic):
             self._client.cancel(self._action_topic)
             Logger.loginfo('Cancelled active action goal.')
+
+    #Canceling move base goal on behavior stop event
+    def on_stop(self):
+        if not self._client.has_result(self._action_topic):
+            self._client.cancel(self._action_topic)
+            Logger.loginfo('Cancelled active action goal.')

--- a/flexbe_utility_states/src/flexbe_utility_states/publish_twist_state.py
+++ b/flexbe_utility_states/src/flexbe_utility_states/publish_twist_state.py
@@ -6,17 +6,12 @@ import rospy
 from flexbe_core.proxy import ProxyPublisher
 from geometry_msgs.msg import Twist
 
-"""Created on June. 21, 2017
-
-@author: Alireza Hosseini
-"""
-
 
 class PublishTwistState(EventState):
 	"""
 	Publishes a velocity command from userdata.
 
-	-- topic 		string 			Topic to which the velocity command will be published.
+	-- topic 		string 			Topic to which the pose will be published.
 
 	># twist		Twist			Velocity command to be published.
 


### PR DESCRIPTION
When using this state in an embedded behavior, it is necessary to implement the "on_stop" method in order to preempt the move base goal.